### PR TITLE
Renovar portafolio a Next.js (App Router) con diseño profesional

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+out
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# PruebasCodex
+# Portafolio profesional en Next.js
 
+Este repositorio contiene una versión renovada del portafolio profesional de **Santiago Jaramo** desarrollada en **Next.js** con un diseño moderno y corporativo.
+
+## Ejecutar en local
+
+```bash
+npm install
+npm run dev
+```
+
+Abrir en `http://localhost:3000`.
+
+## Scripts disponibles
+
+- `npm run dev`: iniciar entorno de desarrollo.
+- `npm run build`: compilar versión de producción.
+- `npm run start`: levantar versión compilada.
+- `npm run lint`: revisar calidad de código.

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,175 @@
+:root {
+  --background: #f5f7fb;
+  --surface: #ffffff;
+  --text: #0f172a;
+  --muted: #475569;
+  --primary: #0f4c81;
+  --primary-strong: #0b3b65;
+  --border: #dbe3ef;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: Inter, 'Segoe UI', Roboto, sans-serif;
+  color: var(--text);
+  background: var(--background);
+  scroll-behavior: smooth;
+}
+
+.container {
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+}
+
+.hero {
+  background: linear-gradient(125deg, #0f4c81, #123e74 55%, #0f2448);
+  color: white;
+  padding: 6rem 0 5rem;
+}
+
+.hero__content {
+  display: grid;
+  gap: 1rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  opacity: 0.85;
+  margin: 0;
+}
+
+h1 {
+  font-size: clamp(2rem, 4vw, 3.3rem);
+  margin: 0;
+}
+
+.subtitle {
+  max-width: 70ch;
+  color: #e2e8f0;
+  margin: 0;
+}
+
+.hero__actions {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.button {
+  padding: 0.75rem 1.1rem;
+  border-radius: 10px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.button--primary {
+  background: white;
+  color: var(--primary);
+}
+
+.button--secondary {
+  border: 1px solid #b8ccf5;
+  color: #f1f5f9;
+}
+
+.section {
+  padding: 3rem 0;
+}
+
+.section h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.65rem;
+}
+
+.section p {
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.chip-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+.chip {
+  background: #e8eff9;
+  color: #0f3f6f;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.92rem;
+}
+
+.timeline,
+.education-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1.15rem;
+  box-shadow: 0 8px 20px rgb(15 23 42 / 5%);
+}
+
+.card h3,
+.card p {
+  margin: 0;
+}
+
+.card__heading {
+  display: grid;
+  gap: 0.25rem;
+  margin-bottom: 0.8rem;
+}
+
+.company {
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.period {
+  color: #64748b;
+  font-size: 0.92rem;
+}
+
+.card ul {
+  margin: 0;
+  padding-left: 1.15rem;
+  color: var(--muted);
+  display: grid;
+  gap: 0.45rem;
+}
+
+.contact-links {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.contact-links a {
+  color: var(--primary);
+  font-weight: 600;
+}
+
+@media (max-width: 700px) {
+  .hero {
+    padding: 4.5rem 0 4rem;
+  }
+
+  .section {
+    padding: 2.5rem 0;
+  }
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,0 +1,15 @@
+import './globals.css';
+
+export const metadata = {
+  title: 'Santiago Jaramo | Portafolio Profesional',
+  description:
+    'Portafolio profesional de Santiago Jaramo, docente universitario, especialista en TI y liderazgo educativo.',
+};
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="es">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,0 +1,157 @@
+const experience = [
+  {
+    role: 'Profesor Titular - Auxiliar 1',
+    company: 'Universidad Técnica de Ambato',
+    period: '2021 - Actualmente',
+    highlights: [
+      'Docente en Algoritmos y Lógica de Programación (PSeInt, Java, Python), Manejo y Configuración de Software (Git y GitHub), Desarrollo Asistido por Software e Ingeniería Económica para Software.',
+      'Responsable del departamento de administración de redes de la FISEI, con planes de mantenimiento preventivo y correctivo para laboratorios.',
+      'Supervisión de personal técnico y soporte a estudiantes, docentes y personal administrativo.',
+    ],
+  },
+  {
+    role: 'CEO - Propietario',
+    company: 'SanTIC Education',
+    period: '2022 - Actualmente',
+    highlights: [
+      'Fundador y líder de una empresa enfocada en capacitaciones de Tecnologías de Información.',
+      'Instructor en fundamentos de programación para niños y adolescentes en instituciones educativas.',
+      'Implementación y administración de plataformas Moodle para empresas y centros de formación, incluyendo servicios activos para una institución educativa en España.',
+    ],
+  },
+  {
+    role: 'Asistente de Tecnologías de Información y Comunicación',
+    company: 'Universidad Técnica de Ambato',
+    period: '2016 - 2021',
+    highlights: [
+      'Desarrollo de software según requerimientos institucionales y administración de plataformas Moodle y Joomla.',
+      'Soporte técnico para programas de educación continua y tutoría virtual en herramientas TIC.',
+      'Diseño instruccional de cursos de educación continua y MOOC.',
+    ],
+  },
+  {
+    role: 'Agente de Soporte Técnico',
+    company: 'Plasticaucho Industrial',
+    period: '2015 - 2016',
+    highlights: [
+      'Soporte técnico en sistemas operativos Windows y herramientas Office 365.',
+      'Administración de usuarios y recursos mediante Active Directory.',
+      'Mantenimiento preventivo y correctivo de equipos informáticos.',
+    ],
+  },
+];
+
+const education = [
+  {
+    institution: 'Universidad Autónoma de Madrid',
+    degree:
+      'Máster Universitario en Investigación e Innovación en Tecnologías de Información y las Comunicaciones',
+    period: '2018 - 2019',
+  },
+  {
+    institution: 'Universidad Técnica de Ambato',
+    degree: 'Ingeniería en Sistemas Computacionales e Informáticos',
+    period: '2010 - 2016',
+  },
+];
+
+const skills = [
+  'Docencia universitaria en programación',
+  'Gestión de redes y laboratorios',
+  'Moodle y plataformas educativas',
+  'Git, GitHub y buenas prácticas de desarrollo',
+  'Diseño instruccional y formación TIC',
+  'Liderazgo y dirección de proyectos educativos',
+];
+
+export default function HomePage() {
+  return (
+    <main>
+      <header className="hero" id="inicio">
+        <div className="hero__content container">
+          <p className="eyebrow">Portafolio Profesional</p>
+          <h1>Santiago Jaramo</h1>
+          <p className="subtitle">
+            Docente universitario, especialista en tecnologías de información y fundador de SanTIC Education.
+          </p>
+          <div className="hero__actions">
+            <a href="#experiencia" className="button button--primary">
+              Ver experiencia
+            </a>
+            <a href="#contacto" className="button button--secondary">
+              Contactar
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <section className="section container" id="perfil">
+        <h2>Perfil profesional</h2>
+        <p>
+          Profesional en Sistemas Computacionales con sólida experiencia en docencia universitaria, liderazgo
+          educativo y administración de infraestructura tecnológica. Mi enfoque combina formación técnica aplicada,
+          innovación pedagógica y ejecución de soluciones TIC para instituciones educativas y organizaciones.
+        </p>
+      </section>
+
+      <section className="section container" id="habilidades">
+        <h2>Habilidades clave</h2>
+        <div className="chip-grid">
+          {skills.map((skill) => (
+            <span key={skill} className="chip">
+              {skill}
+            </span>
+          ))}
+        </div>
+      </section>
+
+      <section className="section container" id="experiencia">
+        <h2>Experiencia</h2>
+        <div className="timeline">
+          {experience.map((job) => (
+            <article className="card" key={`${job.role}-${job.company}`}>
+              <div className="card__heading">
+                <h3>{job.role}</h3>
+                <p className="company">{job.company}</p>
+                <p className="period">{job.period}</p>
+              </div>
+              <ul>
+                {job.highlights.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section container" id="educacion">
+        <h2>Educación</h2>
+        <div className="education-grid">
+          {education.map((item) => (
+            <article className="card" key={`${item.institution}-${item.degree}`}>
+              <h3>{item.institution}</h3>
+              <p>{item.degree}</p>
+              <p className="period">{item.period}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section container" id="contacto">
+        <h2>Contacto</h2>
+        <p>
+          ¿Te interesa colaborar en formación tecnológica, consultoría educativa o proyectos de transformación
+          digital? Estoy disponible para alianzas académicas y empresariales.
+        </p>
+        <p className="contact-links">
+          <a href="https://santiagojaramoya.com" target="_blank" rel="noreferrer">
+            Sitio actual
+          </a>
+          <span>•</span>
+          <a href="mailto:contacto@santiagojaramoya.com">contacto@santiagojaramoya.com</a>
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "santiago-portfolio-next",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.5"
+  }
+}


### PR DESCRIPTION
### Motivation
- Migrar el portafolio a Next.js para tener una base moderna, mantenible y optimizada para producción.
- Presentar el CV y la experiencia profesional con un diseño corporativo, responsivo y fácil de actualizar.
- Implementar una estructura que facilite futuras extensiones (componentes, i18n, despliegue estático/SSR).

### Description
- Añadí una aplicación Next.js usando el App Router con `app/layout.js` (metadatos y raíz HTML) y `app/page.js` (contenido del CV organizado en arreglos reutilizables y secciones: perfil, habilidades, experiencia, educación y contacto).
- Incorporé estilos globales profesionales y responsivos en `app/globals.css` (hero corporativo, tarjetas, chips de habilidades y reglas responsive).
- Añadí `package.json` con scripts `dev`, `build`, `start` y `lint`, y dependencias mínimas (`next`, `react`, `react-dom`) y devDeps de linting; además incluí `.eslintrc.json` y `.gitignore` para el proyecto.
- Actualicé `README.md` con instrucciones de ejecución local y documentación básica del proyecto; la implementación fue realizada manualmente porque la skill `frontend-design` no estaba disponible en el entorno.

### Testing
- Ejecuté `npm install` en el contenedor y falló debido a un `403 Forbidden` al acceder a `https://registry.npmjs.org`, por lo que no fue posible instalar dependencias ni ejecutar `npm run build` o `npm run lint` en este entorno.
- No se ejecutaron tests automáticos adicionales debido a la imposibilidad de instalar dependencias; la estructura de archivos y los nuevos ficheros se verificaron localmente en el árbol del proyecto y están listos para probar en un entorno con acceso al registro npm.
- El README incluye los pasos para probar en local con `npm install` y `npm run dev` una vez que el entorno permita la instalación de paquetes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c70448d3c8832d95a6b7b962c40896)